### PR TITLE
Allow alternative theme engines in Drupal 7 builds

### DIFF
--- a/.build.env
+++ b/.build.env
@@ -5,6 +5,7 @@ drupal_install_command=./scripts/make/install-drupal.sh
 drupal_build_composer_install=Y
 drupal_fix_settings=Y
 drupal_build_drush_make=Y
+drupal_alternative_theme_engine=N
 
 frontend_build=Y
 frontend_dir=./frontend

--- a/scripts/make/clean-drupal.sh
+++ b/scripts/make/clean-drupal.sh
@@ -14,7 +14,6 @@ if [ "$drupal_version" == "7" ]; then
   rm -rf docroot/modules
   rm -rf docroot/profiles
   rm -rf docroot/scripts
-  rm -rf docroot/themes
   rm -rf docroot/.htaccess
   rm -rf docroot/.editorconfig
   rm -rf docroot/.gitignore
@@ -47,6 +46,17 @@ if [ "$drupal_version" == "7" ]; then
   rm -rf docroot/sites/all/modules/README.txt
   rm -rf docroot/sites/all/themes/contrib
   rm -rf docroot/sites/all/themes/README.txt
+
+  if [ "$drupal_alternative_theme_engine" == "Y" ]; then
+    rm -rf docroot/themes/bartik
+    rm -rf docroot/themes/garland
+    rm -rf docroot/themes/seven
+    rm -rf docroot/themes/stark
+    rm -rf docroot/themes/engines/phptemplate
+  else
+    rm -rf docroot/themes
+  fi
+
 elif [ "$drupal_version" == "8" ]; then
   rm -Rf docroot web
 fi


### PR DESCRIPTION
Drupal 7 allows the use of alternative theme engines as can be seen by the use of the twig theme engine here:

https://www.drupal.org/project/tfd7

Allow the alternative engine to be installed into the version control repo under docroot/themes/engines and do not delete them via a `make clean` command.  There is no way to put these engines into the drush make files sensibly and they can require composer dependencies to be installed like libraries making building their assets impractical. 