### PR TITLE
Allow for D7 projects with a custom profile

### DIFF
--- a/.build.env
+++ b/.build.env
@@ -4,6 +4,7 @@ drupal_build_php_tag=wodby/drupal-php:7.1-2.4.5
 drupal_install_command=./scripts/make/install-drupal.sh
 drupal_build_composer_install=Y
 drupal_fix_settings=Y
+drupal_custom_profile=N
 drupal_build_drush_make=Y
 
 frontend_build=Y

--- a/scripts/make/clean-drupal.sh
+++ b/scripts/make/clean-drupal.sh
@@ -12,7 +12,6 @@ if [ "$drupal_version" == "7" ]; then
   rm -rf docroot/includes
   rm -rf docroot/misc
   rm -rf docroot/modules
-  rm -rf docroot/profiles
   rm -rf docroot/scripts
   rm -rf docroot/themes
   rm -rf docroot/.htaccess
@@ -47,6 +46,16 @@ if [ "$drupal_version" == "7" ]; then
   rm -rf docroot/sites/all/modules/README.txt
   rm -rf docroot/sites/all/themes/contrib
   rm -rf docroot/sites/all/themes/README.txt
+
+  if [ "$drupal_custom_profile" == "Y" ]; then
+    rm -rf docroot/profiles/README.txt
+    rm -rf docroot/profiles/minimal
+    rm -rf docroot/profiles/standard
+    rm -rf docroot/profiles/testing
+  else
+    rm -rf docroot/profiles
+  fi
+
 elif [ "$drupal_version" == "8" ]; then
   rm -Rf docroot web
 fi


### PR DESCRIPTION
Projects with a custom profile should not have that profile deleted as part of a make clean.  Projects without them can happily remove the whole folder as before.